### PR TITLE
KJU-39 add ability to add context fields

### DIFF
--- a/otelzap/option.go
+++ b/otelzap/option.go
@@ -73,9 +73,16 @@ func WithTraceIDField(on bool) Option {
 // setting further zap fields based on the span context information
 //
 // This is useful for setting stackdriver tracing information
-//
 func WithSetTraceFieldsFunc(cb SetTraceFieldsFunc) Option {
 	return func(l *Logger) {
 		l.setTraceFieldsFunc = cb
+	}
+}
+
+// WithExtractContextFunc configures the logger to run the given function on every log message to allow
+// setting further zap fields based on the current context
+func WithExtractContextFunc(cb SetContextFieldsFunc) Option {
+	return func(l *Logger) {
+		l.setContextFieldsFunc = cb
 	}
 }

--- a/otelzap/otelzap.go
+++ b/otelzap/otelzap.go
@@ -30,14 +30,16 @@ var (
 // SetTraceFieldsFunc is a callback function that can be used to add additional fields to the log
 // from the given span context
 type SetTraceFieldsFunc func(trace.SpanContext) []zapcore.Field
+type SetContextFieldsFunc func(context.Context) []zapcore.Field
 
 // Logger is a thin wrapper for zap.Logger that adds Ctx method.
 type Logger struct {
 	*zap.Logger
 	skipCaller *zap.Logger
 
-	withTraceID        bool
-	setTraceFieldsFunc SetTraceFieldsFunc
+	withTraceID          bool
+	setTraceFieldsFunc   SetTraceFieldsFunc
+	setContextFieldsFunc SetContextFieldsFunc
 
 	minLevel         zapcore.Level
 	errorStatusLevel zapcore.Level
@@ -179,6 +181,10 @@ func (l *Logger) logFields(
 
 	if l.setTraceFieldsFunc != nil {
 		fields = append(fields, l.setTraceFieldsFunc(span.SpanContext())...)
+	}
+
+	if l.setContextFieldsFunc != nil {
+		fields = append(fields, l.setContextFieldsFunc(ctx)...)
 	}
 
 	return fields


### PR DESCRIPTION
WHAT
Adds a new callback function to options that is called on every log with the context allowing you to pass fields from context to the log

HOW TO USE
```
func SetDefaultFieldsFromContext() otelzap.SetContextFieldsFunc {
	return func(ctx context.Context) []zapcore.Field {
		fields := []zapcore.Field{}
		accountID := cp.GetValueFromContext(ctx, "accountid")
		if accountID != "" {
			fields = append(fields, zap.String("AccountID", accountID))
		}
		fields = append(fields, zap.String("Narf!", accountID))
		return fields
	}
}

// NewOtelLogger is a helper to create an otel logger.
func NewOtelLogger(zLog *zap.Logger, projectid string) *otelzap.Logger {
	opts := []otelzap.Option{
		otelzap.WithMinLevel(zap.InfoLevel),
	}
	opts = append(opts, otelzap.WithExtractContextFunc(SetDefaultFieldsFromContext()))

	log := otelzap.New(zLog, opts...)

	return log
}
```
